### PR TITLE
Enable `ntfy_wrapper` to push to a different `ntfy` server than the default `https://ntfy.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     </a>
 </p>
 <p align="center">
-    <a href="https://pypi.org/project/ntfy-wrapper/"><img src="https://img.shields.io/badge/pypi%20package-0.1.6-yellowgreen" alt="PyPI version" height="18"></a>
+    <a href="https://pypi.org/project/ntfy-wrapper/"><img src="https://img.shields.io/badge/pypi%20package-0.1.7-yellowgreen" alt="PyPI version" height="18"></a>
     <a href="https://ntfy-wrapper.readthedocs.io/en/latest/index.html"><img src="https://img.shields.io/badge/docs-read%20the%20docs-blue" alt="PyPI version" height="18"></a>
     <a href="https://github.com/vict0rsch/ntfy-wrapper/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc"><img src="https://img.shields.io/github/issues-raw/vict0rsch/ntfy-wrapper" alt="Open Issues" height="18"></a>
     <a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/codestyle-black-red" alt="Black code style" height="18"></a>

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ In short, `ntfy-wrapper` will *publish* to a *topic* and you'll have to *subscri
 
 `ntfy-wrapper` uses the INI standard along with `configparser` to parse the configuration file. It expects 2 sections:
 
-1. `[notifier_init]` with optional fields `emails = ` and `topics = ` to define systematic targets for the notification instead of putting them in your Python code
+1. `[notifier_init]` with optional fields `emails = `, `topics = ` and `base_url = ` to define systematic targets for the notification instead of putting them in your Python code. `base_url` allows to push to a different `ntfy` server than the default `https://ntfy.sh`.
 2. `[notify_defaults]` with optional fields listed below, which will define default parameters used by `Notifier.notify(...)`. For instance you can set default `title` and `tags` for your code's `.notify(...)` calls and override them at specific locations with keyword arguments `.notify(title="Non-default title")`
    1. The behavior of the `title`, `priority`, `tags`, `click`, `attach`, `actions` and `icon` keys is described in the [`ntfy` docs](https://ntfy.sh/docs/publish/)
 
@@ -128,6 +128,7 @@ In short, `ntfy-wrapper` will *publish* to a *topic* and you'll have to *subscri
 [notifier_init]
 topics = my-secret-topic-1, mysecrettopic2
 emails = you@foo.bar
+base_url = https://custom-ntfy-instance.io
 
 # For Notifier.notify(title=..., priority=..., etc.)
 [notify_defaults]

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,0 +1,32 @@
+"""
+About: Run a basic notification to an ntfy instance on localhost.
+
+Prerequisites::
+
+    docker run --name=ntfy --rm -it --publish=5555:80 \
+    binwiederhier/ntfy serve \
+        --base-url="http://localhost:5555" \
+        --attachment-cache-dir="/tmp/ntfy-attachments" --attachment-expiry-duration="168h"
+
+    open http://localhost:5555/testdrive
+
+Synopsis::
+
+    pip install ntfy-wrapper
+    wget https://github.com/vict0rsch/ntfy-wrapper/raw/main/examples/basic.py
+    python basic.py
+
+References:
+- https://ntfy.sh/
+- https://ntfy-wrapper.readthedocs.io
+"""
+from ntfy_wrapper import Notifier
+
+
+def main():
+    notifier = Notifier(base_url="http://localhost:5555")
+    notifier.notify(topics="testdrive", message="Hello, world.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ntfy_wrapper/__init__.py
+++ b/ntfy_wrapper/__init__.py
@@ -1,1 +1,8 @@
 from .notifier import Notifier  # noqa: F401
+
+import importlib.metadata as met
+
+
+__version__ = met.version("ntfy_wrapper")
+
+del met

--- a/ntfy_wrapper/cli.py
+++ b/ntfy_wrapper/cli.py
@@ -121,7 +121,27 @@ def add_email(email: str, conf_path: Optional[str] = None):
         print(f"email {email} already exists.")
         raise typer.Abort()
     write_conf(conf_path, conf)
-    print(f"🎉 Email {code(email)} added to {code(conf_path)}", style="green")
+
+
+@add_app.command("base_url")
+def add_base_url(url: str, conf_path: Optional[str] = None):
+    """
+    Adds an url to the config file to override the default https://ntfy.sh.
+    If --conf-path is not given, the current working directory will be used.
+    """
+    conf_path = get_conf_path(conf_path)
+    if not conf_path.exists():
+        raise typer.Abort(f"Config file not found at {str(conf_path)}")
+    conf = load_conf(conf_path)
+    base_url = conf.get("base_url", [])
+    if url not in base_url:
+        base_url.append(url)
+        conf["base_url"] = base_url
+    else:
+        print(f"base_url {url} already exists.")
+        raise typer.Abort()
+    write_conf(conf_path, conf)
+    print(f"🎉 URL {code(url)} added to {code(conf_path)}", style="green")
 
 
 @add_app.command("default")
@@ -189,6 +209,26 @@ def remove_email(email: str, conf_path: Optional[str] = None):
         print(f"🎉 Email {code(email)} removed from {code(conf_path)}", style="green")
     else:
         print(f"Email {code(email)} does not exist. Ignoring.", style="yellow")
+
+
+@remove_app.command("base_url")
+def remove_base_url(url: str, conf_path: Optional[str] = None):
+    """
+    Removes an url from the config file.
+    If --conf-path is not given, the current working directory will be used.
+    """
+    conf_path = get_conf_path(conf_path)
+    if not conf_path.exists():
+        raise typer.BadParameter(f"Config file not found at {str(conf_path)}")
+    conf = load_conf(conf_path)
+    base_url = conf.get("base_url", "")
+    if url in base_url:
+        base_url = [u.strip() for u in base_url.split(",") if u.strip() != url.strip()]
+        conf["base_url"] = ", ".join(base_url)
+        write_conf(conf_path, conf)
+        print(f"🎉 URL {code(url)} removed from {code(conf_path)}", style="green")
+    else:
+        print(f"URL {code(url)} does not exist. Ignoring.", style="yellow")
 
 
 @remove_app.command("default")
@@ -316,18 +356,19 @@ def describe(conf_path: Optional[str] = None):
         raise typer.BadParameter(f"Config file not found at {str(conf_path)}")
     conf = load_conf(conf_path)
     defaults = code(
-        "\n   • ".join(
+        "\n     • ".join(
             [""]
             + [
                 str(k) + " = " + str(v)
                 for k, v in conf.items()
-                if k not in ["topics", "emails"]
+                if k not in ["topics", "emails", "base_url"]
             ]
         )
     )
     print(f"🎉 Configuration file: {code(conf_path)}", style="green")
     print(f"   Topics: {code(', '.join(conf.get('topics', [])))}", style="green")
     print(f"   Emails: {code(', '.join(conf.get('emails', [])))}", style="green")
+    print(f"   Base URLs: {code(', '.join(conf.get('base_url', [])))}", style="green")
     print(f"   Defaults:{defaults}", style="green")
 
 

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -419,6 +419,16 @@ class Notifier:
                 base_urls = [u.strip() for u in base_url.split(",")]
             else:
                 base_urls = [base_url]
+        if not isinstance(base_urls, list) or not base_urls or not base_urls[0]:
+            self._warn(
+                "\nNo base URL specified in conf or as argument,"
+                + " using https://ntfy.sh\n"
+            )
+            base_urls = ["https://ntfy.sh"]
+
+        for u in base_urls:
+            if not u.startswith("http"):
+                self._warn(f"\nBe careful, base url does not start with `http` : {u}\n")
 
         base_urls = [u[:-1] if u.endswith("/") else u for u in base_urls]
 

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -56,28 +56,28 @@ class Notifier:
                 it's probably best you do not track any piece of code containing
                 your topics. That includes the configuration file this class creates
                 automatically (except if ``write`` is False).
-                Defaults to None, meaning a random (uuid) topic will be generated
+                Defaults to ``None``, meaning a random (uuid) topic will be generated
                 for you, and re-used next time, provided you have enabled ``write``.
             emails (Optional[Union[str, List[str]]], optional): String, or list of
                 strings describing the emails to send notifications to by default.
                 Be aware of the rate limits: https://ntfy.sh/docs/publish/#limitations
-                Defaults to None.
+                Defaults to ``None``.
             notify_defaults (Optional[Dict], optional): Dict whose keys and values will
                 be default keyword arguments for the ``Notifier.notify()`` method so
                 that you don't have to write the same stuff again and again throughout
-                your code. Defaults to {}.
-            conf_path (Optional[Union[str, Path]], optional): String or pathlib.Path
+                your code. Defaults to ``{}``.
+            conf_path (Optional[Union[str, Path]], optional): String or ``pathlib.Path``
                 pointing to where the Notifier should get or create its INI
-                configuration file. Defaults to None, meaning ``$CWD/.ntfy.conf``.
+                configuration file. Defaults to ``None``, meaning ``$CWD/.ntfy.conf``.
             write (Optional[bool], optional): Whether to write the Notifier's config
                 if a new topic has to be created because none pre-exist.
-                Defaults to True.
+                Defaults to ``True``.
             warnings (Optional[bool], optional): Whether or not to print warnings,
                 in particular the version control warning if ``write`` is True (by
-                default). Defaults to True.
+                default). Defaults to ``True``.
             verbose (Optional[bool], optional): Whether to describe the Notifier after
                 its initialization from your args and the (potentially non-existing)
-                conf. Defaults to True.
+                conf. Defaults to ``True``.
         """
 
         if isinstance(topics, str):
@@ -173,7 +173,7 @@ class Notifier:
         Args:
             topics (List[str]): The topics to remove.
             write (Optional[bool], optional): Whether to update the config file or not.
-                Defaults to True.
+                Defaults to ``True``.
         """
         for t in topics:
             if t not in self.conf.get("topics", []):
@@ -196,7 +196,7 @@ class Notifier:
         Args:
             emails (List[str]): The emails to remove.
             write (Optional[bool], optional): Whether to update the config file or not.
-                Defaults to True.
+                Defaults to ``True``.
         """
         for e in emails:
             if e not in self.conf.get("emails", []):
@@ -213,7 +213,7 @@ class Notifier:
 
         Args:
             write (Optional[bool], optional): Whether to update the config file or not.
-                Defaults to True.
+                Defaults to ``True``.
         """
         self.conf["topics"] = []
         if write:
@@ -226,7 +226,7 @@ class Notifier:
 
         Args:
             write (Optional[bool], optional): Whether to update the config file or not.
-                Defaults to True.
+                Defaults to ``True``.
         """
         self.conf["emails"] = []
         if write:
@@ -321,26 +321,26 @@ class Notifier:
         Args:
             message (str): The message to send.
             topics (Optional[Union[str, List[str]]], optional): Target topics to notify.
-                Defaults to None.
+                Defaults to ``None``.
             title (Optional[str], optional): The notifications' title.
                 Defaults to "From ntfy_wrapper".
             priority (Optional[int], optional): The notifications' priority.
-                Defaults to None.
+                Defaults to ``None``.
             tags (Optional[Union[str, List[str]]], optional): The notifications' tags.
-                Defaults to None.
+                Defaults to ``None``.
             click (Optional[str], optional):  URL to open when a notification is
-                clicked. Defaults to None.
+                clicked. Defaults to ``None``.
             attach (Optional[str], optional): Attachment to send: either a local image
-                file or an URL pointing to one. Defaults to None.
+                file or an URL pointing to one. Defaults to ``None``.
             actions (Optional[Union[str, List[str]]], optional): A string or list of
                 strings describing actions as per:
                 https://ntfy.sh/docs/publish/#using-a-header
-                Defaults to None.
-            emails (Optional[List[str]], optional): _description_. Defaults to None.
+                Defaults to ``None``.
+            emails (Optional[List[str]], optional): _description_. Defaults to ``None``.
             icon (Optional[str], optional): The notifications' icon as a URL to a
-                remote file. Defaults to None.
+                remote file. Defaults to ``None``.
             base_url (Optional[str], optional): The base URL to use for the API.
-                Defaults to None, i.e. ``https://ntfy.sh`` if ``base_url`` is neither
+                Defaults to ``None``, i.e. ``https://ntfy.sh`` if ``base_url`` is neither
                 an arg nor in the congig.
 
         Raises:

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -15,6 +15,7 @@ from ntfy_wrapper.utils import (
     print,
     KEYS,
 )
+import json
 
 
 class Notifier:
@@ -27,7 +28,7 @@ class Notifier:
         self,
         topics: Optional[Union[str, List[str]]] = None,
         emails: Optional[Union[str, List[str]]] = None,
-        base_url: Optional[str] = None,
+        base_url: Optional[Union[str, List[str]]] = None,
         notify_defaults: Optional[Dict] = {},
         conf_path: Optional[Union[str, Path]] = None,
         write: Optional[bool] = True,
@@ -293,7 +294,8 @@ class Notifier:
         self,
         message: str,
         topics: Optional[Union[str, List[str]]] = None,
-        emails: Optional[List[str]] = None,
+        emails: Optional[Union[str, List[str]]] = None,
+        base_url: Optional[Union[str, List[str]]] = None,
         title: Optional[str] = None,
         priority: Optional[int] = None,
         tags: Optional[Union[str, List[str]]] = None,
@@ -330,6 +332,12 @@ class Notifier:
             message (str): The message to send.
             topics (Optional[Union[str, List[str]]], optional): Target topics to notify.
                 Defaults to ``None``.
+            emails (Optional[Union[str, List[str]]], optional): Target emails to send
+                notifications to. Defaults to ``None``.
+            base_url (Optional[Union[str, List[str]]], optional): The base URL to use
+                for the API. Can be a coma-separated list of URLs. Defaults to ``None``,
+                i.e. ``https://ntfy.sh`` if ``base_url`` is neither an arg nor in the
+                config.
             title (Optional[str], optional): The notifications' title.
                 Defaults to "From ntfy_wrapper".
             priority (Optional[int], optional): The notifications' priority.
@@ -363,7 +371,7 @@ class Notifier:
         defaults = {
             k.capitalize(): v
             for k, v in self.conf.items()
-            if k not in {"topics", "emails"}
+            if k not in {"topics", "emails", "base_url"}
         }
         headers = {**defaults, "priority": priority}
         headers = {k: v for k, v in headers.items() if v is not None}
@@ -374,11 +382,12 @@ class Notifier:
         use_PUT = False
 
         if base_url is None:
-            base_url = self.conf.get("base_url", "https://ntfy.sh")
-        if "," in base_url:
-            base_urls = [u.strip() for u in base_url.split(",")]
-        else:
-            base_urls = [base_url]
+            base_url = self.conf.get("base_url", ["https://ntfy.sh"])
+        if isinstance(base_url, str):
+            if "," in base_url:
+                base_urls = [u.strip() for u in base_url.split(",")]
+            else:
+                base_urls = [base_url]
 
         base_urls = [u[:-1] if u.endswith("/") else u for u in base_urls]
 

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -215,6 +215,29 @@ class Notifier:
         if write:
             self.write_to_conf()
 
+    def remove_base_urls(
+        self,
+        base_urls: List[str],
+        write: Optional[bool] = True,
+    ):
+        """
+        Remove urls from the Notifier's targets.
+        If ``write`` is True, the configuration file is updated.
+        If an url does not exist, it is ignored.
+
+        Args:
+            base_urls (List[str]): The base_urls to remove.
+            write (Optional[bool], optional): Whether to update the config file or not.
+                Defaults to ``True``.
+        """
+        for e in base_urls:
+            if e not in self.conf.get("base_url", []):
+                self._warn(f"URL {e} is not in the list of base_url")
+            else:
+                self.conf["base_url"].remove(e)
+        if write:
+            self.write_to_conf()
+
     def remove_all_topics(self, write: Optional[bool] = True):
         """
         Remove all emails from the Notifier's targets.
@@ -238,6 +261,19 @@ class Notifier:
                 Defaults to ``True``.
         """
         self.conf["emails"] = []
+        if write:
+            self.write_to_conf()
+
+    def remove_all_base_urls(self, write: Optional[bool] = True):
+        """
+        Remove all base urls from the Notifier's targets.
+        If ``write`` is True, the configuration file is updated.
+
+        Args:
+            write (Optional[bool], optional): Whether to update the config file or not.
+                Defaults to ``True``.
+        """
+        self.conf["base_url"] = []
         if write:
             self.write_to_conf()
 

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -160,7 +160,14 @@ class Notifier:
                 "📧 Notifier will send emails to: "
                 + ", ".join([code(e) for e in self.conf["emails"]])
             )
-        keys = [k for k in self.conf.keys() if k not in ["topics", "emails"]]
+        if self.conf.get("base_url"):
+            print(
+                "🏡 Notifier will push to base url: "
+                + ", ".join([code(e) for e in self.conf["base_url"]])
+            )
+        keys = [
+            k for k in self.conf.keys() if k not in ["topics", "emails", "base_url"]
+        ]
         if keys:
             ml = max([len(k) for k in keys])
             print(f"🛠  {code('Notifier.notify(..)')} defaults:")

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -27,6 +27,7 @@ class Notifier:
         self,
         topics: Optional[Union[str, List[str]]] = None,
         emails: Optional[Union[str, List[str]]] = None,
+        base_url: Optional[str] = None,
         notify_defaults: Optional[Dict] = {},
         conf_path: Optional[Union[str, Path]] = None,
         write: Optional[bool] = True,
@@ -62,6 +63,11 @@ class Notifier:
                 strings describing the emails to send notifications to by default.
                 Be aware of the rate limits: https://ntfy.sh/docs/publish/#limitations
                 Defaults to ``None``.
+            base_url (Optional[str], optional): The base url to use to send
+                notifications. It defaults to ``None``, *i.e.* ``https://ntfy.sh``
+                but you can set it to a self-hosted ``ntfy`` instance for example.
+                ``base_url`` can be a list of comma-separated urls, in which case
+                they will all be notified.
             notify_defaults (Optional[Dict], optional): Dict whose keys and values will
                 be default keyword arguments for the ``Notifier.notify()`` method so
                 that you don't have to write the same stuff again and again throughout
@@ -100,6 +106,8 @@ class Notifier:
             conf["topics"] = topics
         if emails is not None:
             conf["emails"] = emails
+        if base_url is not None:
+            conf["base_url"] = base_url
 
         self.conf = conf
 

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -294,6 +294,7 @@ class Notifier:
         actions: Optional[Union[str, List[str]]] = None,
         icon: Optional[str] = None,
         debug: Optional[bool] = False,
+        base_url: Optional[str] = None,
     ) -> List[str]:
         """
         Send a notification to the given topics and emails.
@@ -304,6 +305,8 @@ class Notifier:
 
         The ``defaults`` you may have used in the ``init()`` method are used here.
         You can override them by passing the corresponding arguments.
+
+        In other words: ``arg`` > ``self.conf`` > ``defaults``.
 
         If ``topics`` is None, the topics are taken from the configuration file.
         If ``emails`` is not None, the notification is sent by email to the given
@@ -336,6 +339,9 @@ class Notifier:
             emails (Optional[List[str]], optional): _description_. Defaults to None.
             icon (Optional[str], optional): The notifications' icon as a URL to a
                 remote file. Defaults to None.
+            base_url (Optional[str], optional): The base URL to use for the API.
+                Defaults to None, i.e. ``https://ntfy.sh`` if ``base_url`` is neither
+                an arg nor in the congig.
 
         Raises:
             ValueError: The user cannot specify both ``attach`` and ``message``
@@ -356,6 +362,11 @@ class Notifier:
             raise ValueError("You cannot specify both `attach` and `message`")
 
         use_PUT = False
+
+        if base_url is None:
+            base_url = self.conf.get("base_url", "https://ntfy.sh")
+        if base_url.endswith("/"):
+            base_url = base_url[:-1]
 
         if title is not None:
             headers["Title"] = title
@@ -405,9 +416,9 @@ class Notifier:
 
             if dtype == "email":
                 h["Email"] = dest
-                url = "https://ntfy.sh/alerts"
+                url = f"{base_url}/alerts"
             else:
-                url = f"https://ntfy.sh/{dest}"
+                url = f"{base_url}/{dest}"
 
             dispatchs.append(dest)
 

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -64,11 +64,11 @@ class Notifier:
                 strings describing the emails to send notifications to by default.
                 Be aware of the rate limits: https://ntfy.sh/docs/publish/#limitations
                 Defaults to ``None``.
-            base_url (Optional[str], optional): The base url to use to send
-                notifications. It defaults to ``None``, *i.e.* ``https://ntfy.sh``
-                but you can set it to a self-hosted ``ntfy`` instance for example.
-                ``base_url`` can be a list of comma-separated urls, in which case
-                they will all be notified.
+            base_url (Optional[str], optional): String or list of strings describing
+                the base url to use and send notifications to. It defaults to ``None``,
+                *i.e.* ``https://ntfy.sh`` but you can set it to a self-hosted ``ntfy``
+                instance for example. ``base_url`` can be a list of comma-separated
+                urls, in which case they will all be notified.
             notify_defaults (Optional[Dict], optional): Dict whose keys and values will
                 be default keyword arguments for the ``Notifier.notify()`` method so
                 that you don't have to write the same stuff again and again throughout

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -293,8 +293,8 @@ class Notifier:
         attach: Optional[str] = None,
         actions: Optional[Union[str, List[str]]] = None,
         icon: Optional[str] = None,
-        debug: Optional[bool] = False,
         base_url: Optional[str] = None,
+        debug: Optional[bool] = False,
     ) -> List[str]:
         """
         Send a notification to the given topics and emails.
@@ -342,6 +342,8 @@ class Notifier:
             base_url (Optional[str], optional): The base URL to use for the API. Can be
                 a coma-separated list of URLs. Defaults to ``None``, i.e.
                 ``https://ntfy.sh`` if ``base_url`` is neither an arg nor in the congig.
+            debug (Optional[bool], optional): Whether to print debug information or not.
+                Defaults to ``False``.
 
         Raises:
             ValueError: The user cannot specify both ``attach`` and ``message``

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -438,10 +438,13 @@ class Notifier:
 
                 if not use_PUT:
                     if debug:
-                        print(f"Sending {message} to {dest}:")
+                        print(f"➡️ Sending `{message}` to `{dest}`:")
                         print("    target url: ", url)
                         print("    message: ", message.encode("utf-8"))
-                        print("    headers: ", h)
+                        print(
+                            "    headers: ",
+                            "\n    ".join(json.dumps(h, indent=2).splitlines()),
+                        )
                     requests.post(
                         url,
                         data=message.encode("utf-8"),
@@ -457,7 +460,7 @@ class Notifier:
 
         if debug:
             print(
-                "Debug mode: make sure the above messages,"
+                "\nDebug mode: make sure the above messages,"
                 + " headers and targets are correct."
             )
             print(

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -339,7 +339,6 @@ class Notifier:
         attach: Optional[str] = None,
         actions: Optional[Union[str, List[str]]] = None,
         icon: Optional[str] = None,
-        base_url: Optional[str] = None,
         debug: Optional[bool] = False,
     ) -> List[str]:
         """
@@ -388,12 +387,8 @@ class Notifier:
                 strings describing actions as per:
                 https://ntfy.sh/docs/publish/#using-a-header
                 Defaults to ``None``.
-            emails (Optional[List[str]], optional): _description_. Defaults to ``None``.
             icon (Optional[str], optional): The notifications' icon as a URL to a
                 remote file. Defaults to ``None``.
-            base_url (Optional[str], optional): The base URL to use for the API. Can be
-                a coma-separated list of URLs. Defaults to ``None``, i.e.
-                ``https://ntfy.sh`` if ``base_url`` is neither an arg nor in the congig.
             debug (Optional[bool], optional): Whether to print debug information or not.
                 Defaults to ``False``.
 

--- a/ntfy_wrapper/notifier.py
+++ b/ntfy_wrapper/notifier.py
@@ -470,6 +470,7 @@ class Notifier:
 
         assert isinstance(emails, list)
         assert isinstance(topics, list)
+        assert isinstance(base_urls, list)
 
         dispatchs = []
         for base_url in base_urls:

--- a/ntfy_wrapper/utils.py
+++ b/ntfy_wrapper/utils.py
@@ -46,6 +46,7 @@ Example:
 [notifier_init]
 topics = my-secret-topic-1, mysecrettopic2
 emails = you@foo.bar
+base_url = https://ntfy.your-server.io
 
 # For Notifier.notify(title=..., priority=..., etc.)
 [notify_defaults]

--- a/ntfy_wrapper/utils.py
+++ b/ntfy_wrapper/utils.py
@@ -139,6 +139,7 @@ def write_conf(
     conf = deepcopy(conf)
     topics = conf.pop("topics", None)
     emails = conf.pop("emails", None)
+    base_url = conf.pop("base_url", None)
 
     config = configparser.ConfigParser(allow_no_value=True)
 
@@ -151,6 +152,8 @@ def write_conf(
         config.set("notifier_init", "topics", ",".join(topics))
     if emails:
         config.set("notifier_init", "emails", ",".join(emails))
+    if base_url:
+        config.set("notifier_init", "base_url", base_url)
 
     config.add_section("notify_defaults")
     for k, v in conf.items():

--- a/ntfy_wrapper/utils.py
+++ b/ntfy_wrapper/utils.py
@@ -69,7 +69,7 @@ def get_conf_path(conf_path: Optional[Union[str, Path]] = None) -> Path:
 
     Args:
         conf_path (Optional[Union[str, Path]], optional): Where to look for the config
-            file. Defaults to None.
+            file. Defaults to ``None``.
 
     Returns:
         Path: _description_
@@ -94,7 +94,7 @@ def load_conf(conf_path: Optional[Union[str, Path]] = None) -> dict:
 
     Args:
         conf_path (Optional[Union[str, Path]], optional): Where to load the conf
-        from. Defaults to None.
+        from. Defaults to ``None``.
 
     Returns:
         dict: The configuration as a dictionary.

--- a/ntfy_wrapper/utils.py
+++ b/ntfy_wrapper/utils.py
@@ -113,6 +113,11 @@ def load_conf(conf_path: Optional[Union[str, Path]] = None) -> dict:
                 conf["emails"] = [
                     e.strip() for e in config.get("notifier_init", "emails").split(",")
                 ]
+            if "base_url" in config["notifier_init"]:
+                conf["base_url"] = [
+                    e.strip()
+                    for e in config.get("notifier_init", "base_url").split(",")
+                ]
         if config.has_section("notify_defaults"):
             conf.update(dict(config["notify_defaults"]))
         return conf
@@ -153,7 +158,7 @@ def write_conf(
     if emails:
         config.set("notifier_init", "emails", ",".join(emails))
     if base_url:
-        config.set("notifier_init", "base_url", base_url)
+        config.set("notifier_init", "base_url", ",".join(base_url))
 
     config.add_section("notify_defaults")
     for k, v in conf.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.poetry]
 name = "ntfy-wrapper"
-version = "0.1.6"
+version = "0.1.7"
 description = "Fast & Free notifications for your code: Python wrapper around the ntfy.sh notifications service."
 authors = ["vict0rsch <vsch@pm.me>"]
 license = "MIT"
-readme = "README.md"
+readme = 'README.md'
 packages = [{include = "ntfy_wrapper"}]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Add a new `base_url` field that works just like `emails` and `topics`.

It's in the `[notifier_init]` section in the config `ini` file (`.ntfy.conf`) as a `str` (can be comma-sperated `list`), can be passed as a `Union[str, List[str]]` in the `Notifier` constructor or as a `Union[str, List[str]]` in the `notify()` (= `__call__()`) method.

CLI has been updated too