### PR TITLE
Add basic example program, validating a self-hosted ntfy setup

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,0 +1,32 @@
+"""
+About: Run a basic notification to an ntfy instance on localhost.
+
+Prerequisites::
+
+    docker run --name=ntfy --rm -it --publish=5555:80 \
+    binwiederhier/ntfy serve \
+        --base-url="http://localhost:5555" \
+        --attachment-cache-dir="/tmp/ntfy-attachments" --attachment-expiry-duration="168h"
+
+    open http://localhost:5555/testdrive
+
+Synopsis::
+
+    pip install ntfy-wrapper
+    wget https://github.com/vict0rsch/ntfy-wrapper/raw/main/examples/basic.py
+    python basic.py
+
+References:
+- https://ntfy.sh/
+- https://ntfy-wrapper.readthedocs.io
+"""
+from ntfy_wrapper import Notifier
+
+
+def main():
+    notifier = Notifier(base_url="http://localhost:5555")
+    notifier.notify(topics="testdrive", message="Hello, world.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Dear Victor,

thank you for the swift improvement to support self-hosted ntfy instances. I thought about validating the implementation by sharing a GitHub Gist, but then turned around and added it on behalf of a basic example program here. Maybe you like it.

![image](https://user-images.githubusercontent.com/453543/236026103-4ab4c5c8-7dd9-47f3-b186-1871356e7726.png)
It works. Excellent!

With kind regards,
Andreas.

#### References
- GH-8
- GH-9
- https://github.com/jpmens/mqttwarn/pull/638
